### PR TITLE
Add FAQ on CORS enabled endpoints for Token and Revoke APIs

### DIFF
--- a/en/docs/faq-library/api-creation-and-design.md
+++ b/en/docs/faq-library/api-creation-and-design.md
@@ -142,7 +142,7 @@
     `/_system/config/apimgt/applicationdata/tenant-conf.json`
     file directly in the **Location** field.
 
-    - Click **Edit as text** , add the following properties to the file
+    - Click **Edit as text**, add the following properties to the file
     and click **Save Content**.
 
     ``` java
@@ -182,3 +182,5 @@
 
     - Token Endpoint - https://gateway.api.cloud.wso2.com/token-cors
     - Revoke Endpoint - https://gateway.api.cloud.wso2.com/revoke-cors 
+    
+    

--- a/en/docs/faq-library/api-creation-and-design.md
+++ b/en/docs/faq-library/api-creation-and-design.md
@@ -142,7 +142,7 @@
     `/_system/config/apimgt/applicationdata/tenant-conf.json`
     file directly in the **Location** field.
 
-   - Click **Edit as text** , add the following properties to the file
+    - Click **Edit as text** , add the following properties to the file
     and click **Save Content**.
 
     ``` java
@@ -175,3 +175,10 @@
     returns a 404 error. This does not imply the backend is failing to
     serve other HTTP request methods as well. Therefore you get an
     invalid result when testing.
+    
+14. #### How can I enable CORS on the Token and Revoke APIs for a particular host?
+
+    WSO2 API Cloud provides separate CORS enabled endpoints for Token and Revoke APIs. You can replace your existing endpoints with the following CORS enabled endpoints:
+
+    - Token Endpoint - https://gateway.api.cloud.wso2.com/token-cors
+    - Revoke Endpoint - https://gateway.api.cloud.wso2.com/revoke-cors 


### PR DESCRIPTION
## Purpose
Add an FAQ to address the common question on how to enable CORS on the Token and Revoke APIs for a particular host.
