### PR TITLE
remove js sort on string versions

### DIFF
--- a/en/docs/assets/js/theme.js
+++ b/en/docs/assets/js/theme.js
@@ -97,7 +97,7 @@ request.onload = function() {
        * Appending versions to the version selector dropdown 
        */
       if (dropdown){
-          data.list.sort().forEach(function(key, index){
+          data.list.forEach(function(key, index){
               var versionData = data.all[key];
               
               if(versionData) {


### PR DESCRIPTION

## Purpose
> remove js sort on string versions to prevent the incorrect ordering of the product version dropdown